### PR TITLE
Check position before reseting content inset

### DIFF
--- a/AAPullToRefresh/AAPullToRefresh.m
+++ b/AAPullToRefresh/AAPullToRefresh.m
@@ -201,8 +201,11 @@
 - (void)resetScrollViewContentInset:(actionHandler)handler
 {
     UIEdgeInsets currentInsets = self.scrollView.contentInset;
-    currentInsets.top = self.originalInsetTop;
-    currentInsets.bottom = self.originalInsetBottom;
+    if (self.position == AAPullToRefreshPositionTop) {
+        currentInsets.top = self.originalInsetTop;
+    } else {
+        currentInsets.bottom = self.originalInsetBottom;
+    }
     [self setScrollViewContentInset:currentInsets handler:handler];
 }
 


### PR DESCRIPTION
if the position is top, should not bother the other position when reset the content inset. Or this will have collision with other infinite scroll plugins, e.g., SVInfiniteScroll, which will not show indicator when animating.
